### PR TITLE
LR91 AJ5 and LR87 AJ5

### DIFF
--- a/BDB_RO_configs/RO_BDB_RealPlume/BDB_Titan_Liquid.cfg
+++ b/BDB_RO_configs/RO_BDB_RealPlume/BDB_Titan_Liquid.cfg
@@ -153,3 +153,148 @@
 
 		}
 }
+
+///////Titan II Engines
+@PART[bluedog_LR87_5]:NEEDS[zRealPlume,SmokeScreen,RealismOverhaul]
+{
+			!EFFECTS {}
+
+      @MODULE[ModuleEngines*]
+      {
+        @name = ModuleEnginesFX
+        %powerEffectName = LR87HypergolicLowerComplex
+      }
+
+      PLUME
+      {
+      name = LR87HypergolicLowerComplex
+      transformName = thrustTransform
+      localRotation = 0,0,0
+      localPosition = 0,0,0
+      energy = 1
+      speed = 1
+
+			flarePosition = 0,0,0.5
+			flareScale = 0.25
+
+      plumePosition = 0,0,0.8
+      plumeScale = 1.6
+
+			diahScale = 1.6
+			shock1Scale = 1.6
+
+			fumePosition = 0,0,1.1
+			fumeScale = 1.6
+
+      blazePosition = 0,0,0
+      blazeScale = 1.12
+      }
+}
+
+//Titan II LR91
+@PART[bluedog_LR91_5]:NEEDS[zRealPlume,SmokeScreen,RealismOverhaul]
+{
+		!EFFECTS {}
+    PLUME
+    {
+        name = BDB_HypergolicUpper_White
+        transformName = thrustTransform
+        localRotation = 0,0,0
+        localPosition = 0,0,0
+
+        energy = 1
+        speed = 1
+
+				flarePosition = 0,0,-0.1
+				flareScale = 0.4
+
+        plumePosition = 0,0,0.3
+        plumeScale = 2.1
+
+        fumePosition = 0,0,0.6
+        fumeScale = 1.92
+    }
+		PLUME
+		{
+				name = BDB_HypergolicVernier_White
+				transformName = vernierFX
+				energy = 1
+				speed = 1
+				emissionMult =1
+
+				fumeLightPosition = 0,0,0
+				fumeLightScale = 0.8
+
+				fumeDarkPosition = 0,0,0
+				fumeDarkScale = 0.8
+
+				pumpPosition = 0,0,0
+				pumpScale = 1.6
+		}
+		@MODULE[ModuleEngines*]:HAS[#thrustVectorTransformName[thrustTransform]]
+		{
+			@name = ModuleEnginesFX
+			%powerEffectName = BDB_HypergolicUpper_White
+		}
+		@MODULE[ModuleEngines*]:HAS[#thrustVectorTransformName[vernierThrust]]
+		{
+			@name = ModuleEnginesFX
+			%powerEffectName = BDB_HypergolicVernier_White
+		}
+}
+
+
+//Ficitonal 4 vernier LR91 AJ5
+@PART[bluedog_LR91_5_FourVernier]:NEEDS[zRealPlume,SmokeScreen,RealismOverhaul]
+{
+	!EFFECTS {}
+
+	@MODULE[ModuleEngines*]:HAS[#thrustVectorTransformName[thrustTransform]]
+	{
+		@name = ModuleEnginesFX
+		%powerEffectName = BDB_HypergolicUpper_White
+	}
+	@MODULE[ModuleEngines*]:HAS[#thrustVectorTransformName[vernierTransform]]
+	{
+		@name = ModuleEnginesFX
+		%powerEffectName = BDB_HypergolicVernier_White
+	}
+	  PLUME
+    {
+			name = BDB_HypergolicUpper_White
+			transformName = thrustTransform
+			localRotation = 0,0,0
+			localPosition = 0,0,0
+
+			energy = 1
+			speed = 1
+
+			flarePosition = 0,0,-0.15
+			flareScale = 0.4
+
+			plumePosition = 0,0,0.3
+			plumeScale = 2.1
+
+			fumePosition = 0,0,0.6
+			fumeScale = 1.92
+    }
+
+
+		PLUME
+		{
+				name = BDB_HypergolicVernier_White
+				transformName = vernierTransform
+				energy = 1
+				speed = 1
+				emissionMult =1
+
+				fumeLightPosition = 0,0,0
+				fumeLightScale = 0.8
+
+				fumeDarkPosition = 0,0,0
+				fumeDarkScale = 0.8
+
+				pumpPosition = 0,0,0
+				pumpScale = 1.6
+		}
+}

--- a/BDB_RO_configs/RO_BDB_engines.cfg
+++ b/BDB_RO_configs/RO_BDB_engines.cfg
@@ -39,7 +39,7 @@
 	@description = abc
 	@mass = 0.7
 	@maxTemp = 900
-	
+
 	%skinMaxTemp = 2000
 	%emissiveConstant = 0.6
 	%thermalMassModifier = 1.0
@@ -53,7 +53,7 @@
 
 	!MODULE[PartStatsUpgradeModule] {}
   	!MODULE[ModuleAlternator] {}
-  
+
   	!RESOURCE,*{}
 }
 
@@ -66,7 +66,7 @@
 	@description = abc
 	@mass = 0.7
 	@maxTemp = 900
-	
+
 	%skinMaxTemp = 2000
 	%emissiveConstant = 0.6
 	%thermalMassModifier = 1.0
@@ -80,7 +80,7 @@
 
 	!MODULE[PartStatsUpgradeModule] {}
   	!MODULE[ModuleAlternator] {}
-  
+
   	!RESOURCE,*{}
 }
 
@@ -262,7 +262,7 @@
 {
 	%RSSROConfig = True
 	%engineType = LR101
-  
+
 	%rescaleFactor = 1.6
 	%scale = 1.0
 	@mass = 0.0241
@@ -270,12 +270,12 @@
 	@maxTemp = 673.15
 	%skinTemp = 773.15
 	%stagingIcon = LIQUID_ENGINE
-  
+
 	@tags = atlas lr101 vernier
-  
+
 	!MODULE[ModuleGimbal],* {}
 	!MODULE[ModuleTestSubject] {}
-  
+
 	!RESOURCE,*{}
 }
 
@@ -314,7 +314,7 @@
 	%RSSROConfig = True
 	%engineType = LR101
 
-  
+
 	%rescaleFactor = 1.6
 	%scale = 1.0
 	@mass = 0.0241
@@ -322,12 +322,12 @@
 	@maxTemp = 673.15
 	%skinTemp = 773.15
 	%stagingIcon = LIQUID_ENGINE
-  
+
 	@tags = atlas lr101 vernier
-  
+
 	!MODULE[ModuleGimbal],* {}
 	!MODULE[ModuleTestSubject] {}
-  
+
 	!RESOURCE,*{}
 }
 
@@ -489,7 +489,7 @@
 	@description = abc
 	@mass = 0.09
 	@maxTemp = 900
-	
+
 	%skinMaxTemp = 2000
 	%emissiveConstant = 0.6
 	%thermalMassModifier = 1.0
@@ -507,7 +507,7 @@
 	@description = abc
 	@mass = 0.09
 	@maxTemp = 900
-	
+
 	%skinMaxTemp = 2000
 	%emissiveConstant = 0.6
 	%thermalMassModifier = 1.0
@@ -525,7 +525,7 @@
 	@description = abc
 	@mass = 0.09
 	@maxTemp = 900
-	
+
 	%skinMaxTemp = 2000
 	%emissiveConstant = 0.6
 	%thermalMassModifier = 1.0
@@ -543,7 +543,7 @@
 	@description = abc
 	@mass = 0.09
 	@maxTemp = 900
-	
+
 	%skinMaxTemp = 2000
 	%emissiveConstant = 0.6
 	%thermalMassModifier = 1.0
@@ -561,7 +561,7 @@
 	@description = abc
 	@mass = 0.09
 	@maxTemp = 900
-	
+
 	%skinMaxTemp = 2000
 	%emissiveConstant = 0.6
 	%thermalMassModifier = 1.0
@@ -579,7 +579,7 @@
 	@description = A development of the venerable LR-79 engine, the RS-27 is both more powerful and more efficient. The perfect engine for a new family of rockets based on old designs.
 	@mass = 0.589
 	@maxTemp = 900
-	
+
 	%skinMaxTemp = 2000
 	%emissiveConstant = 0.6
 	%thermalMassModifier = 1.0
@@ -653,7 +653,7 @@
             	@key,1 = 1 264
         	}
     	}
-	
+
 	!MODULE[ModuleB9PartSwitch],0
 	{
 	}
@@ -1099,7 +1099,116 @@
 	%thermalMassModifier = 1.0
 	%skinMassPerArea = 4
 
-	engineType = LR87
+	MODULE
+	{
+		name = ModuleEngineConfigs
+		type = ModuleEngines
+		configuration = LR87-AJ-7
+		@configuration:NEEDS[RP-0] = LR87-AJ-5
+		modded = false
+		origMass = 0.839
+		CONFIG
+		{
+			// [5], [6]. [7]
+			// Using a mix of the data -- the 281s vac in 5 seems obviously wrong
+			// compared to everything else. For now going with 257/289.
+			// Best guess is 5 uses very early -5s, and the other sources report
+			// late model -5s.
+			name = LR87-AJ-5
+			minThrust = 1075.5
+			maxThrust = 1075.5
+			heatProduction = 100
+			PROPELLANT
+			{
+				name = Aerozine50
+				ratio = 0.455
+				DrawGauge = True
+			}
+			PROPELLANT
+			{
+				name = NTO
+				ratio = 0.545
+			}
+			atmosphereCurve
+			{
+				key = 0 289
+				key = 1 257
+			}
+			ullage = True
+			ignitions = 1
+			IGNITOR_RESOURCE
+			{
+				name = ElectricCharge
+				amount = 2.0
+			}
+			massMult = 0.8808104887
+		}
+		CONFIG
+		{
+			// using Gemini mission reports here, with 7's vac Isp
+			name = LR87-AJ-7
+			minThrust = 1097.2
+			maxThrust = 1097.2
+			heatProduction = 100
+			PROPELLANT
+			{
+				name = Aerozine50
+				ratio = 0.455
+				DrawGauge = True
+			}
+			PROPELLANT
+			{
+				name = NTO
+				ratio = 0.545
+			}
+			atmosphereCurve
+			{
+				key = 0 296
+				key = 1 261
+			}
+			ullage = True
+			ignitions = 1
+			IGNITOR_RESOURCE
+			{
+				name = ElectricCharge
+				amount = 2.0
+			}
+			massMult = 0.8498212157 // nautix 713kg per
+		}
+		CONFIG
+		{
+			// can't find good data on these.
+			// Let's claim 450klbf, 298/262 for the 12 AR nozzle.
+			name = LR87-AJ-9
+			minThrust = 1130
+			maxThrust = 1130
+			heatProduction = 100
+			PROPELLANT
+			{
+				name = Aerozine50
+				ratio = 0.455
+				DrawGauge = True
+			}
+			PROPELLANT
+			{
+				name = NTO
+				ratio = 0.545
+			}
+			atmosphereCurve
+			{
+				key = 0 298
+				key = 1 262
+			}
+			ullage = True
+			ignitions = 1
+			IGNITOR_RESOURCE
+			{
+				name = ElectricCharge
+				amount = 2.0
+			}
+			massMult = 0.95 // Guess, FIXME. Bigger nozzle.
+		}
+	}
 
 	!MODULE[ModuleAlternator]
 	{
@@ -1131,61 +1240,134 @@
 
 	//%engineType = LR91
 
-	@MODULE[ModuleEnginesFX],0
-    	{
-        	@minThrust = 443.2
-        	@maxThrust = 443.2
-        	@heatProduction = 100
-        	%ullage = True
-        	%pressureFed = False
-        	%ignitions = 1
-
-        	@PROPELLANT[LiquidFuel]
-        	{
-            	@name = Aerozine50
-            	@ratio = 0.474
-        	}
-
-        	@PROPELLANT[Oxidizer]
-        	{
-            	@name = NTO
-            	@ratio = 0.526
-        	}
-
-		IGNITOR_RESOURCE
+	MODULE
+	{
+		name = ModuleEngineConfigs
+		modded = false
+		configuration = LR91-AJ-7
+		@configuration:NEEDS[RP-0] = LR91-AJ-5
+		origMass = 0.5
+		CONFIG
 		{
-			name = ElectricCharge
-			amount = 0.8
-		}
+			// [5]
+			name = LR91-AJ-5
+			minThrust = 443.2
+			maxThrust = 443.2 //minus vernier thrust
+			heatProduction = 160
+			PROPELLANT
+			{
+				name = Aerozine50
+				ratio = 0.474
+				DrawGauge = True
+			}
+			PROPELLANT
+			{
+				name = NTO
+				ratio = 0.526
+			}
+			atmosphereCurve
+			{
+				key = 0 312
+				key = 1 200
+			}
+			ullage = True
+			ignitions = 1
 
-		@atmosphereCurve
-        	{
-            	@key,0 = 0 312
-            	@key,1 = 1 200
-        	}
-    	}
+			IGNITOR_RESOURCE
+			{
+				name = ElectricCharge
+				amount = 0.8
+			}
+			massMult = 1.0
+		}
+		CONFIG
+		{
+			// Gemini 8 data
+			name = LR91-AJ-7
+			minThrust = 461.1
+			maxThrust = 461.1 // minus vernier
+			heatProduction = 160
+			PROPELLANT
+			{
+				name = Aerozine50
+				ratio = 0.474
+				DrawGauge = True
+			}
+			PROPELLANT
+			{
+				name = NTO
+				ratio = 0.526
+			}
+			atmosphereCurve
+			{
+				key = 0 315
+				key = 1 200
+			}
+			ullage = True
+			ignitions = 1
+
+			IGNITOR_RESOURCE
+			{
+				name = ElectricCharge
+				amount = 0.8
+			}
+			massMult = 1.13
+		}
+		CONFIG
+		{
+			name = LR91-AJ-9
+			minThrust = 451.1
+			maxThrust = 451.1 // added the Verniers back to the thrust
+			heatProduction = 160
+			PROPELLANT
+			{
+				name = Aerozine50
+				ratio = 0.474
+				DrawGauge = True
+			}
+			PROPELLANT
+			{
+				name = NTO
+				ratio = 0.526
+			}
+			atmosphereCurve
+			{
+				key = 0 316
+				key = 1 200
+			}
+			ullage = True
+			ignitions = 1
+
+			IGNITOR_RESOURCE
+			{
+				name = ElectricCharge
+				amount = 0.8
+			}
+			massMult = 1.18 // FIXME no sourcing
+		}
+	}
 
 
 	@MODULE[ModuleEnginesFX],1
-    	{
-        	@minThrust = 5
-        	@maxThrust = 5
-        	@heatProduction = 100
-        	%ullage = True
-        	%pressureFed = False
-        	%ignitions = 1
+	{
+  	@minThrust = 5
+  	@maxThrust = 5
+  	@heatProduction = 100
+  	%ullage = True
+  	%pressureFed = False
+  	%ignitions = 1
 
-        	@PROPELLANT[LiquidFuel]
-        	{
-            	@name = Aerozine50
-            	@ratio = 0.474
-        	}
+  	@PROPELLANT[LiquidFuel]
+  	{
+      	@name = Aerozine50
+      	@ratio = 0.474
+  	}
 
-        	@PROPELLANT[Oxidizer]
-        	{
-            	@name = NTO
-            	@ratio = 0.526
-        	}
+  	@PROPELLANT[Oxidizer]
+  	{
+      	@name = NTO
+      	@ratio = 0.526
+  	}
 
 		IGNITOR_RESOURCE
 		{
@@ -1194,11 +1376,11 @@
 		}
 
 		@atmosphereCurve
-        	{
-            	@key,0 = 0 312
-            	@key,1 = 1 200
-        	}
-    	}
+  	{
+      	@key,0 = 0 312
+      	@key,1 = 1 200
+  	}
+	}
 
 	!MODULE[ModuleB9PartSwitch],0
 	{
@@ -1230,61 +1412,134 @@
 
 	//%engineType = LR91
 
-	@MODULE[ModuleEnginesFX],0
-    	{
-        	@minThrust = 443.2
-        	@maxThrust = 443.2
-        	@heatProduction = 100
-        	%ullage = True
-        	%pressureFed = False
-        	%ignitions = 1
-
-        	@PROPELLANT[LiquidFuel]
-        	{
-            	@name = Aerozine50
-            	@ratio = 0.474
-        	}
-
-        	@PROPELLANT[Oxidizer]
-        	{
-            	@name = NTO
-            	@ratio = 0.526
-        	}
-
-		IGNITOR_RESOURCE
+	MODULE
+	{
+		name = ModuleEngineConfigs
+		modded = false
+		configuration = LR91-AJ-7
+		@configuration:NEEDS[RP-0] = LR91-AJ-5
+		origMass = 0.5
+		CONFIG
 		{
-			name = ElectricCharge
-			amount = 0.8
-		}
+			// [5]
+			name = LR91-AJ-5
+			minThrust = 443.2
+			maxThrust = 443.2 //minus vernier thrust
+			heatProduction = 160
+			PROPELLANT
+			{
+				name = Aerozine50
+				ratio = 0.474
+				DrawGauge = True
+			}
+			PROPELLANT
+			{
+				name = NTO
+				ratio = 0.526
+			}
+			atmosphereCurve
+			{
+				key = 0 312
+				key = 1 200
+			}
+			ullage = True
+			ignitions = 1
 
-		@atmosphereCurve
-        	{
-            	@key,0 = 0 312
-            	@key,1 = 1 200
-        	}
-    	}
+			IGNITOR_RESOURCE
+			{
+				name = ElectricCharge
+				amount = 0.8
+			}
+			massMult = 1.0
+		}
+		CONFIG
+		{
+			// Gemini 8 data
+			name = LR91-AJ-7
+			minThrust = 461.1
+			maxThrust = 461.1 // minus vernier
+			heatProduction = 160
+			PROPELLANT
+			{
+				name = Aerozine50
+				ratio = 0.474
+				DrawGauge = True
+			}
+			PROPELLANT
+			{
+				name = NTO
+				ratio = 0.526
+			}
+			atmosphereCurve
+			{
+				key = 0 315
+				key = 1 200
+			}
+			ullage = True
+			ignitions = 1
+
+			IGNITOR_RESOURCE
+			{
+				name = ElectricCharge
+				amount = 0.8
+			}
+			massMult = 1.13
+		}
+		CONFIG
+		{
+			name = LR91-AJ-9
+			minThrust = 451.1
+			maxThrust = 451.1 // added the Verniers back to the thrust
+			heatProduction = 160
+			PROPELLANT
+			{
+				name = Aerozine50
+				ratio = 0.474
+				DrawGauge = True
+			}
+			PROPELLANT
+			{
+				name = NTO
+				ratio = 0.526
+			}
+			atmosphereCurve
+			{
+				key = 0 316
+				key = 1 200
+			}
+			ullage = True
+			ignitions = 1
+
+			IGNITOR_RESOURCE
+			{
+				name = ElectricCharge
+				amount = 0.8
+			}
+			massMult = 1.18 // FIXME no sourcing
+		}
+	}
 
 
 	@MODULE[ModuleEnginesFX],1
-    	{
-        	@minThrust = 5
-        	@maxThrust = 5
-        	@heatProduction = 100
-        	%ullage = True
-        	%pressureFed = False
-        	%ignitions = 1
+	{
+  	@minThrust = 2.5
+  	@maxThrust = 2.5
+  	@heatProduction = 100
+  	%ullage = True
+  	%pressureFed = False
+  	%ignitions = 1
 
-        	@PROPELLANT[LiquidFuel]
-        	{
-            	@name = Aerozine50
-            	@ratio = 0.474
-        	}
+  	@PROPELLANT[LiquidFuel]
+  	{
+      	@name = Aerozine50
+      	@ratio = 0.474
+  	}
 
-        	@PROPELLANT[Oxidizer]
-        	{
-            	@name = NTO
-            	@ratio = 0.526
-        	}
+  	@PROPELLANT[Oxidizer]
+  	{
+      	@name = NTO
+      	@ratio = 0.526
+  	}
 
 		IGNITOR_RESOURCE
 		{
@@ -1293,11 +1548,11 @@
 		}
 
 		@atmosphereCurve
-        	{
-            	@key,0 = 0 312
-            	@key,1 = 1 200
-        	}
-    	}
+  	{
+      	@key,0 = 0 312
+      	@key,1 = 1 200
+  	}
+	}
 
 	!MODULE[ModuleB9PartSwitch],0
 	{
@@ -1617,7 +1872,7 @@
 	@title = Ranger/Mariner Midcourse Correction Engine
 	@mass = 0.015
 	@maxTemp = 900
-	
+
 	%skinMaxTemp = 2000
 	%emissiveConstant = 0.6
 	%thermalMassModifier = 1.0
@@ -1650,6 +1905,6 @@
             	@key,1 = 1 112
         	}
     	}
-	
+
 	!RESOURCE, * {}
 }


### PR DESCRIPTION
includes engine type configs for the AJ5 models for AJ5, A7 and AJ9

Realplumes for LR91 AJ5, LR91 4 vernier Aj5 and LR87 Aj5 (and associated subtypes)